### PR TITLE
Fixed get_all_horoscope_data api error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -173,3 +173,4 @@ config.ini
 *.session-journal
 data/
 .vscode/
+astroenv

--- a/VedicAstroAPI.py
+++ b/VedicAstroAPI.py
@@ -58,7 +58,8 @@ async def get_chart_data(input: ChartInput):
     """
     horoscope = VedicAstro.VedicHoroscopeData(input.year, input.month, input.day, 
                                               input.hour, input.minute, input.second,
-                                              input.utc, input.latitude, input.longitude, 
+                                              input.latitude, input.longitude, 
+                                              input.utc,
                                               input.ayanamsa, input.house_system)
     chart = horoscope.generate_chart()
     


### PR DESCRIPTION
Using appropriate values to call `VedicHoroscopeData`.
Earlier method parameters were not aligned with the method signature causing 500 error